### PR TITLE
Increase geolocation timeout

### DIFF
--- a/my-project-frontend/src/views/forum/TopicList.vue
+++ b/my-project-frontend/src/views/forum/TopicList.vue
@@ -87,8 +87,9 @@ navigator.geolocation.getCurrentPosition(position => {
     weather.success = true
   })
 }, {
-  timeout: 3000,
-  enableHighAccuracy: true
+  enableHighAccuracy: true,
+  timeout: 10000,
+  maximumAge: 60000
 })
 
 onMounted(() => {


### PR DESCRIPTION
## Summary
- raise the geolocation timeout in TopicList to 10 seconds to reduce premature failures
- cache recent position results by enabling a 60-second maximumAge when requesting weather data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8d8026350832f83a4e1f1a5c7a205