### PR TITLE
style: redesign frontend with apple-inspired visuals

### DIFF
--- a/my-project-frontend/src/App.vue
+++ b/my-project-frontend/src/App.vue
@@ -36,7 +36,7 @@ onMounted(() => {
 
 <template>
   <el-config-provider :locale="en">
-      <div class="wrapper">
+      <div class="wrapper apple-wrapper">
           <router-view/>
       </div>
   </el-config-provider>
@@ -45,5 +45,36 @@ onMounted(() => {
 <style scoped>
 .wrapper {
   line-height: 1.5;
+  min-height: 100vh;
+}
+
+.apple-wrapper {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(145deg, rgba(239, 244, 255, 0.9), rgba(255, 255, 255, 0.8));
+}
+
+.dark .apple-wrapper {
+  background: radial-gradient(circle at top, rgba(32, 35, 48, 0.95), rgba(14, 16, 24, 0.98));
+}
+</style>
+
+<style>
+:root {
+  font-family: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", sans-serif;
+  color: #0a0a0a;
+  background-color: #f5f6f8;
+  font-smooth: always;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  margin: 0;
+  background-color: transparent;
+}
+
+html.dark {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: #0b0c12;
 }
 </style>

--- a/my-project-frontend/src/components/LightCard.vue
+++ b/my-project-frontend/src/components/LightCard.vue
@@ -6,8 +6,23 @@
 
 <style scoped>
 .light-card {
-    background-color: var(--el-bg-color);
-    border-radius: 5px;
-    padding: 10px;
+    background: rgba(255, 255, 255, 0.82);
+    border-radius: 20px;
+    padding: 18px;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(20px);
+    transition: transform .25s ease, box-shadow .25s ease;
+}
+
+.light-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 22px 44px rgba(15, 23, 42, 0.16);
+}
+
+:global(.dark) .light-card {
+    background: rgba(24, 32, 52, 0.78);
+    border: 1px solid rgba(148, 163, 255, 0.2);
+    box-shadow: 0 22px 44px rgba(2, 6, 23, 0.65);
 }
 </style>

--- a/my-project-frontend/src/views/IndexView.vue
+++ b/my-project-frontend/src/views/IndexView.vue
@@ -66,20 +66,24 @@ function deleteAllNotification() {
 <template>
   <div class="main-content" v-loading="loading" element-loading-text="Entering, please wait...">
     <el-container style="height: 100%" v-if="!loading">
-      <el-header class="main-content-header">
-        <div style="width: 320px;height: 32px">
-          <el-image class="logo" src="https://element-plus.org/images/element-plus-logo.svg"/>
+      <el-header class="main-content-header glass-header">
+        <div class="brand">
+          <div class="brand-icon"></div>
+          <div class="brand-copy">
+            <div class="brand-title">StudySphere</div>
+            <div class="brand-subtitle">Designed with an Apple-inspired touch</div>
+          </div>
         </div>
-        <div style="flex: 1;padding: 0 20px;text-align: center">
-          <el-input v-model="searchInput.text" style="width: 100%;max-width: 500px"
-                    placeholder="Search forum content...">
+        <div class="search-area">
+          <el-input v-model="searchInput.text" class="search-input"
+                    placeholder="Search across your campus universe...">
             <template #prefix>
               <el-icon>
                 <Search/>
               </el-icon>
             </template>
             <template #append>
-              <el-select style="width: 120px" v-model="searchInput.type">
+              <el-select class="search-filter" v-model="searchInput.type">
                 <el-option value="1" label="Forum Square"/>
                 <el-option value="2" label="Campus Events"/>
                 <el-option value="3" label="Confession Wall"/>
@@ -119,14 +123,14 @@ function deleteAllNotification() {
           </el-popover>
         </user-info>
       </el-header>
-      <el-container>
-        <el-aside width="230px">
-          <el-scrollbar style="height: calc(100vh - 55px)">
+      <el-container class="content-body">
+        <el-aside width="250px" class="main-aside glass-panel">
+          <el-scrollbar class="aside-scroll">
             <el-menu
                 router
                 :default-active="$route.path"
                 :default-openeds="['1', '2', '3']"
-                style="min-height: calc(100vh - 55px)">
+                class="aside-menu">
               <el-sub-menu :index="(index + 1).toString()"
                            v-for="(menu, index) in userMenu">
                 <template #title>
@@ -148,7 +152,7 @@ function deleteAllNotification() {
           </el-scrollbar>
         </el-aside>
         <el-main class="main-content-page">
-          <el-scrollbar style="height: calc(100vh - 55px)">
+          <el-scrollbar class="page-scroll">
             <router-view v-slot="{ Component }">
               <transition name="el-fade-in-linear" mode="out-in">
                 <component :is="Component" style="height: 100%"/>
@@ -182,55 +186,281 @@ function deleteAllNotification() {
   }
 }
 
-.main-content-page {
-  padding: 0;
-  background-color: #f7f8fa;
-}
-
-.dark .main-content-page {
-  background-color: #212225;
-}
-
 .main-content {
   height: 100vh;
   width: 100vw;
+  position: relative;
+  background: linear-gradient(160deg, rgba(244, 247, 255, 0.88) 0%, #ffffff 45%, rgba(233, 238, 255, 0.92) 100%);
+  overflow: hidden;
 }
 
-.main-content-header {
-  border-bottom: solid 1px var(--el-border-color);
-  height: 55px;
+.main-content::before {
+  content: "";
+  position: absolute;
+  top: -220px;
+  right: -160px;
+  width: 520px;
+  height: 520px;
+  background: radial-gradient(circle at center, rgba(99, 102, 241, 0.55), rgba(59, 130, 246, 0.05) 72%);
+  filter: blur(70px);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.dark .main-content {
+  background: radial-gradient(circle at top, rgba(11, 17, 33, 0.95), rgba(9, 11, 19, 0.98) 65%, rgba(4, 6, 12, 1));
+}
+
+.dark .main-content::before {
+  background: radial-gradient(circle at center, rgba(99, 102, 241, 0.45), rgba(15, 23, 42, 0.1) 70%);
+  opacity: 0.6;
+}
+
+.glass-header {
+  border-bottom: none;
+  height: 84px;
   display: flex;
   align-items: center;
   box-sizing: border-box;
+  margin: 32px 36px 0;
+  padding: 0 32px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(28px) saturate(140%);
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  gap: 24px;
+}
 
-  .logo {
-    height: 32px;
+.dark .glass-header {
+  background: rgba(24, 32, 52, 0.72);
+  border: 1px solid rgba(148, 163, 255, 0.18);
+  box-shadow: 0 28px 46px rgba(2, 6, 23, 0.65);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 260px;
+}
+
+.brand-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, #6366f1, #8b5cf6);
+  box-shadow: 0 14px 24px rgba(99, 102, 241, 0.35);
+  position: relative;
+}
+
+.brand-icon::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.6);
+  filter: blur(4px);
+}
+
+.brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.brand-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #1e1f25;
+}
+
+.brand-subtitle {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(30, 31, 37, 0.55);
+}
+
+.dark .brand-title {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.dark .brand-subtitle {
+  color: rgba(226, 232, 240, 0.55);
+}
+
+.search-area {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.search-input {
+  width: 100%;
+  max-width: 520px;
+  --el-input-bg-color: rgba(255, 255, 255, 0.65);
+  --el-input-border-color: transparent;
+  --el-input-hover-border-color: rgba(99, 102, 241, 0.45);
+  --el-input-focus-border-color: rgba(99, 102, 241, 0.65);
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.65);
+  overflow: hidden;
+}
+
+.search-filter {
+  width: 150px;
+  background: transparent;
+  border: none;
+}
+
+.content-body {
+  padding: 28px 36px 36px;
+  display: flex;
+  gap: 28px;
+}
+
+.main-aside {
+  border-radius: 32px;
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(28px);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.15);
+  padding: 24px 0;
+}
+
+.aside-scroll {
+  height: calc(100vh - 210px);
+  padding: 0 8px;
+}
+
+.aside-menu {
+  min-height: calc(100vh - 210px);
+  background: transparent;
+  border-right: none;
+  padding: 0 16px;
+}
+
+.aside-menu .el-menu-item {
+  border-radius: 18px;
+  margin: 6px 0;
+  height: 44px;
+  line-height: 44px;
+}
+
+.aside-menu .el-sub-menu__title {
+  height: 48px;
+  line-height: 48px;
+}
+
+.main-content-page {
+  padding: 0;
+  background: rgba(255, 255, 255, 0.86);
+  border-radius: 36px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+}
+
+.page-scroll {
+  height: calc(100vh - 210px);
+  padding: 0 12px 12px;
+}
+
+.dark .main-aside {
+  background: rgba(24, 32, 52, 0.72);
+  border: 1px solid rgba(148, 163, 255, 0.18);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.65);
+}
+
+.dark .aside-menu {
+  background: transparent;
+}
+
+.dark .main-content-page {
+  background: rgba(24, 32, 52, 0.78);
+  border: 1px solid rgba(148, 163, 255, 0.2);
+  box-shadow: 0 30px 60px rgba(2, 6, 23, 0.7);
+}
+
+.dark .search-input {
+  --el-input-bg-color: rgba(24, 32, 52, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 255, 0.18);
+}
+
+.dark .brand-icon::after {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+.main-content-header .user-info {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.main-content-header .user-info .el-avatar:hover {
+  cursor: pointer;
+}
+
+.main-content-header .user-info .profile {
+  text-align: right;
+  margin-right: 20px;
+}
+
+.main-content-header .user-info .profile :first-child {
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 20px;
+}
+
+.main-content-header .user-info .profile :last-child {
+  font-size: 10px;
+  color: grey;
+}
+
+@media (max-width: 1280px) {
+  .glass-header {
+    flex-wrap: wrap;
+    height: auto;
+    padding: 18px 24px;
+    gap: 18px;
   }
 
-  .user-info {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
+  .brand {
+    min-width: 100%;
+  }
 
-    .el-avatar:hover {
-      cursor: pointer;
-    }
+  .search-area {
+    width: 100%;
+    order: 3;
+  }
 
-    .profile {
-      text-align: right;
-      margin-right: 20px;
+  .content-body {
+    flex-direction: column;
+  }
 
-      :first-child {
-        font-size: 18px;
-        font-weight: bold;
-        line-height: 20px;
-      }
+  .main-aside {
+    width: 100% !important;
+  }
+}
 
-      :last-child {
-        font-size: 10px;
-        color: grey;
-      }
-    }
+@media (max-width: 768px) {
+  .main-content {
+    background: linear-gradient(175deg, rgba(244, 247, 255, 0.92), #ffffff 70%);
+  }
+
+  .glass-header {
+    margin: 24px 18px 0;
+  }
+
+  .content-body {
+    padding: 24px 18px 28px;
+  }
+
+  .page-scroll,
+  .aside-scroll {
+    height: auto;
+    max-height: none;
   }
 }
 </style>

--- a/my-project-frontend/src/views/WelcomeView.vue
+++ b/my-project-frontend/src/views/WelcomeView.vue
@@ -1,42 +1,242 @@
 <script setup>
-import bg from '@/assets/111.jpg' // 本地图片由 Vite 解析成可用的 URL
+import bg from '@/assets/111.jpg'
 </script>
 
 <template>
-  <div style="width: 100vw;height: 100vh;overflow: hidden;display: flex">
+  <div class="welcome-container">
+    <section class="hero-panel">
+      <div class="hero-background">
+        <el-image class="hero-image" :src="bg" fit="cover"/>
+      </div>
+      <div class="hero-overlay"></div>
+      <div class="hero-inner">
+        <span class="hero-badge">StudySphere</span>
+        <h1 class="hero-title">Learn boldly. Create beautifully.</h1>
+        <p class="hero-description">
+          Experience a refined campus community inspired by the elegance of Apple design.
+          Plan your study sessions, stay current with events, and grow alongside creators who value craft.
+        </p>
+        <div class="hero-features">
+          <span class="feature-chip">Immersive learning journeys</span>
+          <span class="feature-chip">Curated campus events</span>
+          <span class="feature-chip">Effortless collaboration</span>
+        </div>
+      </div>
+    </section>
 
-    <div style="flex: 1; background-color: black; display: flex; justify-content: center; align-items: center;">
-      <el-image
-          style="height: 100%; width: auto"
-          :src="bg"
-      />
-    </div>
-    <div class="welcome-title">
-      <div style="font-size: 30px;font-weight: bold">Welcome to our learning platform</div>
-      <div style="margin-top: 10px">Here you can learn how to use Java, how to build websites, and communicate closely with the father of Java.</div>
-      <div style="margin-top: 5px">Here you can make gay friends, because it’s all men—no girls study Java.</div>
-    </div>
-    <div class="right-card">
-      <router-view v-slot="{ Component }">
-        <transition name="el-fade-in-linear" mode="out-in">
-          <component :is="Component" style="height: 100%"/>
-        </transition>
-      </router-view>
-    </div>
+    <section class="auth-panel">
+      <div class="auth-card">
+        <router-view v-slot="{ Component }">
+          <transition name="el-fade-in-linear" mode="out-in">
+            <component :is="Component" class="auth-component"/>
+          </transition>
+        </router-view>
+      </div>
+      <div class="auth-subtext">Designed for clarity, focus, and a touch of wonder.</div>
+    </section>
   </div>
 </template>
 
 <style scoped>
-.right-card {
-  width: 400px;
-  z-index: 1;
-  background-color: var(--el-bg-color);
+.welcome-container {
+  width: 100%;
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(320px, 1fr);
+  gap: 56px;
+  padding: 64px 80px;
+  box-sizing: border-box;
+  position: relative;
 }
-.welcome-title {
+
+.hero-panel {
+  position: relative;
+  border-radius: 42px;
+  overflow: hidden;
+  display: flex;
+  align-items: stretch;
+  background: linear-gradient(140deg, #0f172a, #1e293b 48%, #312e81);
+  color: #ffffff;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.35);
+  isolation: isolate;
+}
+
+.hero-background,
+.hero-overlay {
   position: absolute;
-  bottom: 30px;
-  left: 30px;
-  color: white;
-  text-shadow: 0 0 10px black;
+  inset: 0;
+}
+
+.hero-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(125%) contrast(110%);
+  opacity: 0.35;
+}
+
+.hero-overlay {
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.35), transparent 55%),
+              radial-gradient(circle at 80% 30%, rgba(148, 163, 255, 0.55), transparent 60%),
+              linear-gradient(120deg, rgba(15, 23, 42, 0.65), rgba(49, 46, 129, 0.55));
+  mix-blend-mode: lighten;
+  opacity: 0.9;
+}
+
+.hero-inner {
+  position: relative;
+  padding: 80px 70px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 28px;
+  max-width: 620px;
+  z-index: 1;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.22);
+  color: rgba(255, 255, 255, 0.92);
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 13px;
+  backdrop-filter: blur(14px);
+}
+
+.hero-title {
+  font-size: clamp(2.8rem, 3.6vw, 3.6rem);
+  font-weight: 700;
+  line-height: 1.05;
+  margin: 0;
+}
+
+.hero-description {
+  font-size: 1.05rem;
+  line-height: 1.8;
+  max-width: 520px;
+  color: rgba(255, 255, 255, 0.82);
+  margin: 0;
+}
+
+.hero-features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.feature-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 9px 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  backdrop-filter: blur(16px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+}
+
+.auth-panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+  position: relative;
+}
+
+.auth-card {
+  border-radius: 32px;
+  padding: 40px 32px;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(28px);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+}
+
+.auth-component {
+  height: 100%;
+}
+
+.auth-subtext {
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.55);
+  letter-spacing: 0.02em;
+  text-align: center;
+}
+
+.dark .welcome-container {
+  background: transparent;
+}
+
+.dark .hero-panel {
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.94));
+  box-shadow: 0 40px 100px rgba(0, 0, 0, 0.65);
+}
+
+.dark .hero-overlay {
+  opacity: 0.6;
+}
+
+.dark .feature-chip {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 255, 0.22);
+}
+
+.dark .auth-card {
+  background: rgba(17, 24, 39, 0.86);
+  border: 1px solid rgba(148, 163, 255, 0.22);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.6);
+}
+
+.dark .auth-subtext {
+  color: rgba(226, 232, 240, 0.55);
+}
+
+@media (max-width: 1440px) {
+  .welcome-container {
+    padding: 48px 48px;
+    gap: 40px;
+  }
+
+  .hero-inner {
+    padding: 64px 56px;
+  }
+}
+
+@media (max-width: 1100px) {
+  .welcome-container {
+    grid-template-columns: 1fr;
+    padding: 48px 36px 120px;
+  }
+
+  .auth-panel {
+    max-width: 460px;
+    margin: -120px auto 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .welcome-container {
+    padding: 32px 24px 96px;
+  }
+
+  .hero-inner {
+    padding: 48px 32px;
+  }
+
+  .auth-panel {
+    margin-top: -96px;
+  }
+
+  .auth-card {
+    padding: 32px 24px;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- refresh global layout wrapper with SF-inspired typography and gradients
- rebuild the welcome screen with glassmorphism hero and responsive Apple-style composition
- restyle dashboard shell, navigation, and cards for a polished glass design aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3b548c4c4832faa0b3ea3a4976448